### PR TITLE
Remove now incorrect sentence about iss in SD-JWT VC

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -241,7 +241,7 @@ This profile defines the following additional requirements for IETF SD-JWT VCs a
 
 * The Issuer MUST NOT make any of the JWT Claims in the table above to be selectively disclosable, so that they are always present in the SD-JWT-VC presented by the Holder.
 * It is at the discretion of the Issuer whether to use `exp` claim and/or a `status` claim to express the validity period of an SD-JWT-VC. The Wallet and the verifier  MUST support both mechanisms.
-* The `iss` claim MUST be an HTTPS URL. The `iss` value is used to obtain Issuer’s signing key as defined in (#issuer-key-resolution).
+* The `iss` claim MUST be an HTTPS URL.
 * The `vct` JWT claim as defined in [@!I-D.ietf-oauth-sd-jwt-vc].
 * The `cnf` claim [@!RFC7800] MUST conform to the definition given in [@!I-D.ietf-oauth-sd-jwt-vc]. Implementations conforming to this profile MUST include the JSON Web Key [@!RFC7517] in the `jwk` sub claim.
 * The public key used to validate the signature on the Status List Token MUST be included in the `x5c` JOSE header of the Token.


### PR DESCRIPTION
x5c is required as per https://github.com/openid/oid4vc-haip/pull/178

This leaves it unsaid what iss is actually set to. I raised https://github.com/openid/oid4vc-haip/issues/215
in case we need to say something about that but think the scope of this PR should just be removing the text that is now inconsistent with other parts of HAIP.