### PR TITLE
require c_nonce for key bound creds

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -133,7 +133,7 @@ When ecosystem policies require Issuer Authentication to a higher level than pos
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
 
-If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present in the Credential Issuer Metadata.
+If the Issuer supports Credential Configurations that require key binding indicated by `cryptographic_binding_methods_supported`, the `nonce_endpoint` MUST be present in the Credential Issuer Metadata.
 
 ## Credential Offer
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -133,7 +133,7 @@ When ecosystem policies require Issuer Authentication to a higher level than pos
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
 
-If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present in the Credential Issuer.
+If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present in the Credential Issuer Metadata.
 
 ## Credential Offer
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -133,6 +133,8 @@ When ecosystem policies require Issuer Authentication to a higher level than pos
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
 
+If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present .
+
 ## Credential Offer
 
 * The Grant Type `authorization_code` MUST be supported as defined in Section 4.1.1 in [@!OIDF.OID4VCI]

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -133,7 +133,7 @@ When ecosystem policies require Issuer Authentication to a higher level than pos
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
 
-If the Issuer supports Credential Configurations that require key binding indicated by `cryptographic_binding_methods_supported`, the `nonce_endpoint` MUST be present in the Credential Issuer Metadata.
+If the Issuer supports Credential Configurations that require key binding, as indicated by the presence of `cryptographic_binding_methods_supported`, the `nonce_endpoint` MUST be present in the Credential Issuer Metadata.
 
 ## Credential Offer
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -133,7 +133,7 @@ When ecosystem policies require Issuer Authentication to a higher level than pos
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
 
-If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present .
+If the Issuer supports Credential Configurations that require key binding, the `nonce_endpoint` MUST be present in the Credential Issuer.
 
 ## Credential Offer
 


### PR DESCRIPTION
Logic behind this and based on the following that is already in the OID4VCI spec:
- if a credential configuration contains `cryptographic_binding_methods_supported`, proof(s) have to be provided
- if `nonce_endpoint` present, then wallet must provide `c_nonce` in proof(s)
- if `nonce_endpoint` present, then the issuer must check that the nonce in the proof(s) matches the provided `c_nonce`

Hence, all we need to do is to require `nonce_endpoint` to be present if there is a credential configuration that requires key binding.

Editorially, I'm not sure if the newline is required @jogu 

closes #149