### PR TITLE
Mandate AKI for trusted_authorities

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -190,7 +190,7 @@ Requirements for both the Wallet and the Verifier:
 * Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
 * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 * For Client Identifier Prefix as introduced in Section 5.10 of [@!OIDF.OID4VP], `x509_hash` MUST be supported by the Wallet and used by the Verifier.
-* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported
+* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported.
 
 # OpenID for Verifiable Presentations over W3C Digital Credentials API
 
@@ -203,9 +203,9 @@ The following requirements apply for both, the Wallet and the Verifier, unless s
 * Response encryption MUST be performed as specified in [@!OIDF.OID4VP, section 8.3]. The JWE `alg` (algorithm) header parameter (see [@!RFC7516, section 4.1.1])
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
-* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported
+* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported.
 
-Note that Authority Key Identifiers can be used to also construct requests for issuers from other trust mechanisms that are X.509 based like VICAL as introduced in [@ISO.18013-5] or the ETSI Trusted Lists [@ETSI.TL]
+Note that the Authority Key Identifiers mechanism can be leveraged to construct requests for issuers from other trust mechanisms that are X.509 based like ISO mDL VICAL as introduced in [@ISO.18013-5] or the ETSI Trusted Lists [@ETSI.TL]. This can be achieved by collecting all relevant X.509 certificates of either mechanism and converting them into an array of the encoded KeyIdentifiers to identify the trusted issuers.
 
 ## ISO mdoc specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -190,7 +190,7 @@ Requirements for both the Wallet and the Verifier:
 * Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
 * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 * For Client Identifier Prefix as introduced in Section 5.10 of [@!OIDF.OID4VP], `x509_hash` MUST be supported by the Wallet and used by the Verifier.
-* The DCQL query and response as defined in Section 6 of [@!OIDF.OID4VP] MUST be used.
+* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported
 
 # OpenID for Verifiable Presentations over W3C Digital Credentials API
 
@@ -203,8 +203,9 @@ The following requirements apply for both, the Wallet and the Verifier, unless s
 * Response encryption MUST be performed as specified in [@!OIDF.OID4VP, section 8.3]. The JWE `alg` (algorithm) header parameter (see [@!RFC7516, section 4.1.1])
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
-* The DCQL query and response as defined in Section 6 of [@!OIDF.OID4VP] MUST be used. Presentation Exchange as defined in Sections 5.4 and 5.5 of [@!OIDF.OID4VP] MUST NOT be used.
+* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported
 
+Note that Authority Key Identifiers can be used to also construct requests for issuers from other trust mechanisms that are X.509 based like VICAL as introduced in [@ISO.18013-5] or the ETSI Trusted Lists [@ETSI.TL]
 
 ## ISO mdoc specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
 
@@ -440,6 +441,16 @@ The security considerations in [@!OIDF.OID4VCI] and [@!OIDF.OID4VP] apply.
         </front>
 </reference>
 
+<reference anchor="ETSI.TL" target="https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf">
+        <front>
+          <title>ETSI TS 119 612 V2.3.1 Electronic Signatures and Infrastructures (ESI); Trusted Lists </title>
+          <author>
+            <organization>European Telecommunications Standards Institute (ETSI)</organization>
+          </author>
+          <date month="Nov" year="2024"/>
+        </front>
+</reference>
+
 # Acknowledgements {#Acknowledgements}
 
 We would like to thank Paul Bastian, Christian Bormann, Mike Jones, Oliver Terbu, Daniel Fett, and Giuseppe De Marco for their valuable feedback and contributions to this specification.
@@ -458,6 +469,8 @@ The technology described in this specification was made available from contribut
 
    -04
 
+   * mandate support for aki trusted_authorities method
+   * remove presentation exchange reference since it was removed in openid4vp
    * x509_san_dns & verifier_attestations client id prefixes are no longer permitted, x509_hash must be used
    * x.509 certificates are now the mandatory mechanism for SD-JWT VC issuer key resolution
    * `x5c` header in Status List Token must be present

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -205,7 +205,7 @@ The following requirements apply for both, the Wallet and the Verifier, unless s
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
 * The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported.
 
-Note that the Authority Key Identifiers mechanism can be leveraged to construct requests for issuers from other trust mechanisms that are X.509 based like ISO mDL VICAL as introduced in [@ISO.18013-5] or the ETSI Trusted Lists [@ETSI.TL]. This can be achieved by collecting all relevant X.509 certificates of either mechanism and converting them into an array of the encoded KeyIdentifiers to identify the trusted issuers.
+Note that the Authority Key Identifiers mechanism can be used to support multiple trust mechanisms that are X.509 based, such as ISO mDL VICAL (as introduced in [@ISO.18013-5]) or ETSI Trusted Lists [@ETSI.TL]. This can be achieved by collecting the relevant X.509 certificates for the trusted Issuers and putting the encoded KeyIdentifers from the certificates into the `aki` array .
 
 ## ISO mdoc specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -193,7 +193,7 @@ Requirements for both the Wallet and the Verifier:
 * Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
 * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 * For Client Identifier Prefix as introduced in Section 5.10 of [@!OIDF.OID4VP], `x509_hash` MUST be supported by the Wallet and used by the Verifier.
-* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported.
+* The Authority Key Identifier (`aki`)-based Trusted Authority Query (`trusted_authorities`) for DCQL, as defined in section 6.1.1.1 of [@!OIDF.OID4VP], MUST be supported.
 
 # OpenID for Verifiable Presentations over W3C Digital Credentials API
 
@@ -206,9 +206,9 @@ The following requirements apply for both, the Wallet and the Verifier, unless s
 * Response encryption MUST be performed as specified in [@!OIDF.OID4VP, section 8.3]. The JWE `alg` (algorithm) header parameter (see [@!RFC7516, section 4.1.1])
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
-* The Authority Key Identifier (`aki`) based Trusted Authority Query (`trusted_authorities`) for DCQL as defined in section 6.1 of [@!OIDF.OID4VP] MUST be supported.
+* The Authority Key Identifier (`aki`)-based Trusted Authority Query (`trusted_authorities`) for DCQL, as defined in section 6.1.1.1 of [@!OIDF.OID4VP], MUST be supported.
 
-Note that the Authority Key Identifiers mechanism can be used to support multiple trust mechanisms that are X.509 based, such as ISO mDL VICAL (as introduced in [@ISO.18013-5]) or ETSI Trusted Lists [@ETSI.TL]. This can be achieved by collecting the relevant X.509 certificates for the trusted Issuers and putting the encoded KeyIdentifers from the certificates into the `aki` array .
+Note that the Authority Key Identifiers mechanism can be used to support multiple X.509-based trust mechanisms, such as ISO mDL VICAL (as introduced in [@ISO.18013-5]) or ETSI Trusted Lists [@ETSI.TL]. This is achieved by collecting the relevant X.509 certificates for the trusted Issuers and including the encoded KeyIdentifers from the certificates in the `aki` array .
 
 ## ISO mdoc specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
 


### PR DESCRIPTION
Closes #160

I think we should restructure some parts of haip into a separate section - e.g., move openid4vp & dcql  requirements that are shared by sd-jwt vc, dc api, mdoc profiles into their own section. I would propose to do so in a new PR once the remaining ones that are awaiting reviews are merged?