### PR TITLE
refactor OID4VC sections to include ISO mdocs

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -184,7 +184,9 @@ The Authorization Server MUST support metadata according to [@!RFC8414].
 The Credential Issuer MUST support metadata retrieval according to Section 12.2.2 of [@!OIDF.OID4VCI].
 The Credential Issuer metadata MUST include a scope for every Credential Configuration it supports.
 
-# OpenID for Verifiable Presentations profile for IETF SD-JWT VC
+# OpenID for Verifiable Presentations
+
+## OpenID for Verifiable Presentations via Redirects
 
 Requirements for both the Wallet and the Verifier:
 
@@ -195,7 +197,7 @@ Requirements for both the Wallet and the Verifier:
 * For Client Identifier Prefix as introduced in Section 5.10 of [@!OIDF.OID4VP], `x509_hash` MUST be supported by the Wallet and used by the Verifier.
 * The DCQL query and response as defined in Section 6 of [@!OIDF.OID4VP] MUST be used.
 
-# OpenID for Verifiable Presentations over W3C Digital Credentials API
+## OpenID for Verifiable Presentations via W3C Digital Credentials API
 
 The following requirements apply for both, the Wallet and the Verifier, unless specified otherwise:
 
@@ -206,25 +208,19 @@ The following requirements apply for both, the Wallet and the Verifier, unless s
 * Response encryption MUST be performed as specified in [@!OIDF.OID4VP, section 8.3]. The JWE `alg` (algorithm) header parameter (see [@!RFC7516, section 4.1.1])
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
-* The DCQL query and response as defined in Section 6 of [@!OIDF.OID4VP] MUST be used. Presentation Exchange as defined in Sections 5.4 and 5.5 of [@!OIDF.OID4VP] MUST NOT be used.
 
-
-## ISO mdoc specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
+## ISO mdoc specific requirements for OpenID for Verifiable Presentations
 
 Requirements for both the Wallet and the Verifier:
 
 * ISO mdoc Credential Format specific DCQL parameter, `intent_to_retain` defined in Annex B.3.1 of [@!OIDF.OID4VP] MUST be present.
 * When multiple ISO mdocs are being returned, each ISO mdoc MUST be returned in a separate `DeviceResponse` (as defined in 8.3.2.1.2.2 of [@!ISO.18013-5]), each matching to a respective DCQL query. Therefore, the resulting `vp_token` contains multiple `DeviceResponse` instances.
 
-Note that the Credential Format Identifier and `SessionTranscript` CBOR structure are defined in [@!OIDF.OID4VP].
+Note that the Credential Format Identifier and `SessionTranscript` CBOR structures are defined in [@!OIDF.OID4VP].
 
+## IETF SD-JWT VC specific requirements for OpenID for Verifiable Presentations
 
-## IETF SD-JWT VC specific requirements for OpenID for Verifiable Presentations over W3C Digital Credentials API
-
-Requirements for both the Wallet and the Verifier:
-
-* The Credential Format identifier MUST be `dc+sd-jwt`.
-* IETF SD-JWT VC Credential Format specific DCQL parameters as defined in Section 6.4.1 of [@!OIDF.OID4VP] MUST be used.
+Note that the Credential Format Identifier is defined in [@!OIDF.OID4VP].
 
 # SD-JWT VCs {#sd-jwt-vc}
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -188,7 +188,7 @@ The Credential Issuer metadata MUST include a scope for every Credential Configu
 
 Both the Wallet and the Verifier:
 
-* MUST support at least one of the Credential format profiles and protocol extensions defined in (#vc_profiles).
+* MUST support at least one of the Credential format profiles and protocol extensions defined in (#vc_sd_jwt_profile).
 
 ## OpenID for Verifiable Presentations via Redirects
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -187,6 +187,7 @@ The Credential Issuer metadata MUST include a scope for every Credential Configu
 # OpenID for Verifiable Presentations
 
 Both the Wallet and the Verifier:
+
 * MUST support at least one of the Credential format profiles and protocol extensions defined in (#vc_profiles).
 
 ## OpenID for Verifiable Presentations via Redirects

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -220,7 +220,9 @@ Note that the Credential Format Identifier and `SessionTranscript` CBOR structur
 
 ## IETF SD-JWT VC specific requirements for OpenID for Verifiable Presentations
 
-Note that the Credential Format Identifier is defined in [@!OIDF.OID4VP].
+Requirements for both the Wallet and the Verifier:
+
+* The Credential Format identifier MUST be `dc+sd-jwt`.
 
 # SD-JWT VCs {#sd-jwt-vc}
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -186,6 +186,9 @@ The Credential Issuer metadata MUST include a scope for every Credential Configu
 
 # OpenID for Verifiable Presentations
 
+Both the Wallet and the Verifier:
+* MUST support at least one of the Credential format profiles and protocol extensions defined in (#vc_profiles).
+
 ## OpenID for Verifiable Presentations via Redirects
 
 Requirements for both the Wallet and the Verifier:

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -498,7 +498,10 @@ The technology described in this specification was made available from contribut
    * Old link in section 8 & clarify a note on claim based binding in OpenID4VP in HAIP #183
    * Clarify clause 4.1 statement #169
    * add a list of all specifications being profiled #145
-   * refactor sections to align ISO mdoc issuance and presentation with SD-JWT VC
+   * refactor to separate generic and SD-JWT clauses
+   * add support for ISO mdoc isssuance
+   * add support for ISO mdoc when using redirect-based OID4VP
+   * restrict OID4VP redirect flow to same-device case
 
    -03
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -56,12 +56,8 @@ This specification uses the terms "Holder", "Issuer", "Verifier", "Wallet", "Wal
 
 This specification enables interoperable implementations of the following flows:
 
-* Issuance of IETF SD-JWT VC using OpenID4VCI
-* Issuance of ISO mdocs using OpenID4VCI
-* Presentation of IETF SD-JWT VC using OpenID4VP
-* Presentation of IETF SD-JWT VC using OpenID4VP over W3C Digital Credentials API
-* Presentation of ISO mdocs using OpenID4VP
-* Presentation of ISO mdocs using OpenID4VP over W3C Digital Credentials API
+* Issuance using OpenID4VCI for IETF SD-JWT VC and ISO mdocs
+* Presentation using OpenID4VP via redirects or the W3C Digital Credentials API for IETF SD-JWT VC and ISO mdocs
 * OpenID4VC Credential Format Profiles
 
 Implementations of this specification do not have to implement all of the flows listed above, but they MUST be compliant to all of the requirements for a particular flow they chose to implement.

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -201,7 +201,7 @@ Additional requirements for OpenID4VP are defined in (#oid4vp-redirects) and (#o
 The following requirements apply to OpenID4VP via redirects, unless specified otherwise:
 
 * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported by the Wallet and the Verifier. Implementations MAY support other ways to invoke the Wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
-* The Verifier MUST use signed requests.
+* Signed Authorization Requests MUST be used by utilizing JWT-Secured Authorization Request (JAR) [@!RFC9101] with the `request_uri` parameter.
 * The Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
 * The Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -500,7 +500,6 @@ The technology described in this specification was made available from contribut
    * refactor to separate generic and SD-JWT clauses
    * add support for ISO mdoc isssuance
    * add support for ISO mdoc when using redirect-based OID4VP
-   * restrict OID4VP redirect flow to same-device case
 
    -03
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -204,7 +204,6 @@ The following requirements apply to OpenID4VP via redirects, unless specified ot
 * Signed Authorization Requests MUST be used by utilizing JWT-Secured Authorization Request (JAR) [@!RFC9101] with the `request_uri` parameter.
 * Response encryption MUST be used by utilizing response mode `direct_post.jwt`, as defined in Section 8.3 of [@!OIDF.OID4VP]. Security Considerations in Section 14.3 of [@!OIDF.OID4VP] MUST be applied.
 * Same-device flows MUST be used by enforcing `redirect_uri` in response to the HTTP POST request from the Wallet, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations in Section 13.3 and Security Considerations in Section 14.2 of [@!OIDF.OID4VP] MUST be applied. Verifiers MUST abort the validation if the `redirect_uri` was not called by the Wallet or could not be matched with the initial browser session.
-* The Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 
 ### OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -204,7 +204,6 @@ The following requirements apply to OpenID4VP via redirects, unless specified ot
 * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported by the Wallet and the Verifier. Implementations MAY support other ways to invoke the Wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
 * Signed Authorization Requests MUST be used by utilizing JWT-Secured Authorization Request (JAR) [@!RFC9101] with the `request_uri` parameter.
 * Response encryption MUST be used by utilizing response mode `direct_post.jwt`, as defined in Section 8.3 of [@!OIDF.OID4VP]. Security Considerations in Section 14.3 of [@!OIDF.OID4VP] MUST be applied.
-* Same-device flows MUST be used by enforcing `redirect_uri` in response to the HTTP POST request from the Wallet, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations in Section 13.3 and Security Considerations in Section 14.2 of [@!OIDF.OID4VP] MUST be applied. Verifiers MUST abort the validation if the `redirect_uri` was not called by the Wallet or could not be matched with the initial browser session.
 
 ## OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -202,7 +202,8 @@ The following requirements apply to OpenID4VP via redirects, unless specified ot
 
 * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported by the Wallet and the Verifier. Implementations MAY support other ways to invoke the Wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
 * Signed Authorization Requests MUST be used by utilizing JWT-Secured Authorization Request (JAR) [@!RFC9101] with the `request_uri` parameter.
-* The Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
+* Response encryption MUST be used by utilizing response mode `direct_post.jwt`, as defined in Section 8.3 of [@!OIDF.OID4VP]. Security Considerations in Section 14.3 of [@!OIDF.OID4VP] MUST be applied.
+* Same-device flows MUST be used by enforcing `redirect_uri` in response to the HTTP POST request from the Wallet, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations in Section 13.3 and Security Considerations in Section 14.2 of [@!OIDF.OID4VP] MUST be applied. Verifiers MUST abort the validation if the `redirect_uri` was not called by the Wallet or could not be matched with the initial browser session.
 * The Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
 
 ### OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -194,11 +194,9 @@ The following requirements apply to OpenID4VP, irrespective of the flow and Cred
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
 
-Additional requirements for OpenID4VP are defined in (#oid4vp-flows) and (#oid4vp-dc-api).
+Additional requirements for OpenID4VP are defined in (#oid4vp-redirects) and (#oid4vp-dc-api).
 
-## Requirements specific to Flows {#oid4vp-flows}
-
-### OpenID for Verifiable Presentations via Redirects {#oid4vp-redirects}
+## OpenID for Verifiable Presentations via Redirects {#oid4vp-redirects}
 
 The following requirements apply to OpenID4VP via redirects, unless specified otherwise:
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -59,6 +59,7 @@ This specification enables interoperable implementations of the following flows:
 * Issuance of IETF SD-JWT VC using OpenID4VCI
 * Presentation of IETF SD-JWT VC using OpenID4VP
 * Presentation of IETF SD-JWT VC using OpenID4VP over W3C Digital Credentials API
+* Presentation of ISO mdocs using OpenID4VP
 * Presentation of ISO mdocs using OpenID4VP over W3C Digital Credentials API
 
 Implementations of this specification do not have to implement all of the flows listed above, but they MUST be compliant to all of the requirements for a particular flow they chose to implement.
@@ -113,8 +114,6 @@ The following items are out of scope for the current version of this document, b
 * Trust Management refers to authorization of an Issuer to issue certain types of credentials, authorization of the Wallet to be issued certain types of credentials, authorization of the Verifier to receive certain types of credentials. Although X.509 PKI is extensively utilized in this profile, the methods for establishing trust or obtaining root certificates are out of the scope of this specification.
 * Protocol for presentation of Verifiable Credentials for offline use-cases, e.g. over BLE.
 * Profile of OpenID4VCI to issue ISO mdoc [@!ISO.18013-5] is defined in ISO 23220-3.
-* Profile of OpenID4VP without using W3C Digital Credentials API to present ISO mdocs is
-defined in [@ISO.18013-7]. For more details, also see Annex B.3 in [@!OIDF.OID4VP].
 
 # OpenID for Verifiable Credential Issuance
 
@@ -186,49 +185,67 @@ The Credential Issuer metadata MUST include a scope for every Credential Configu
 
 # OpenID for Verifiable Presentations
 
-Both the Wallet and the Verifier:
+The following requirements apply to OpenID4VP, irrespective of the flow and Credential Format, unless specified otherwise:
 
-* MUST support at least one of the Credential format profiles and protocol extensions defined in (#vc_sd_jwt_profile).
-
-## OpenID for Verifiable Presentations via Redirects
-
-Requirements for both the Wallet and the Verifier:
-
-* As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported. Implementations MAY support other ways to invoke the Wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
-* Response type MUST be `vp_token`.
-* Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
-* Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
-* For Client Identifier Prefix as introduced in Section 5.10 of [@!OIDF.OID4VP], `x509_hash` MUST be supported by the Wallet and used by the Verifier.
+* The Wallet and the Verifier MUST support at least one of the Credential formats defined in (#credential-formats).
+* The Response type MUST be `vp_token`.
+* For signed requests, the Verifier MUST use, and the Wallet MUST support the Client Identifier Prefix `x509_hash` as defined in Section 5.10 of [@!OIDF.OID4VP].
 * The DCQL query and response as defined in Section 6 of [@!OIDF.OID4VP] MUST be used.
-
-## OpenID for Verifiable Presentations via W3C Digital Credentials API
-
-The following requirements apply for both, the Wallet and the Verifier, unless specified otherwise:
-
-* MUST support Annex A in [@!OIDF.OID4VP] that defines how to use OpenID4VP over the W3C Digital Credentials API.
-  * The Wallet MUST support both signed and unsigned requests as defined in Annex A.3.1 and A.3.2 of [@!OIDF.OID4VP]. The Verifier MAY support signed requests, unsigned requests, or both.
-* Wallet Invocation is done via the W3C Digital Credentials API or an equivalent platform API. Any other mechanism, including Custom URL schemes, MUST NOT be used.
-* Response Mode MUST be `dc_api.jwt`. The response MUST be encrypted.
 * Response encryption MUST be performed as specified in [@!OIDF.OID4VP, section 8.3]. The JWE `alg` (algorithm) header parameter (see [@!RFC7516, section 4.1.1])
   value `ECDH-ES` (as defined in [@!RFC7518, section 4.6]), with key agreement utilizing keys on the `P-256` curve (see [@!RFC7518, section 6.2.1.1]) MUST be supported.
   The JWE `enc` (encryption algorithm) header parameter (see [@!RFC7516, section 4.1.2]) value `A128GCM` (as defined in [@!RFC7518, section 5.3]) MUST be supported.
 
-## ISO mdoc specific requirements for OpenID for Verifiable Presentations
+Additional requirements for OpenID4VP are defined in (#oid4vp-flows) and (#oid4vp-dc-api).
 
-Requirements for both the Wallet and the Verifier:
+## Requirements specific to Flows {#oid4vp-flows}
 
-* ISO mdoc Credential Format specific DCQL parameter, `intent_to_retain` defined in Annex B.3.1 of [@!OIDF.OID4VP] MUST be present.
+### OpenID for Verifiable Presentations via Redirects {#oid4vp-redirects}
+
+The following requirements apply to OpenID4VP via redirects, unless specified otherwise:
+
+* As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported by the Wallet and the Verifier. Implementations MAY support other ways to invoke the Wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
+* The Verifier MUST use signed requests.
+* The Response mode MUST be `direct_post.jwt`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post.jwt` are given in Section 14.3 of [@!OIDF.OID4VP].
+* The Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
+
+### OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}
+
+The following requirements apply to OpenID4VP via the W3C Digital Credentials API, unless specified otherwise:
+
+* Wallet Invocation is done via the W3C Digital Credentials API or an equivalent platform API. Any other mechanism, including Custom URL schemes, MUST NOT be used.
+* The Response Mode MUST be `dc_api.jwt`.
+* The Verifier and Wallet MUST use Annex A in [@!OIDF.OID4VP] that defines how to use OpenID4VP over the W3C Digital Credentials API.
+* The Wallet MUST support both signed and unsigned requests as defined in Annex A.3.1 and A.3.2 of [@!OIDF.OID4VP]. The Verifier MAY support signed requests, unsigned requests, or both.
+
+## Requirements specific to Credential Formats
+
+### ISO Mobile Documents or mdocs (ISO/IEC 18013 and ISO/IEC 23220 series)
+
+The following requirements apply to all OpenID4VP flows when the mdoc Credential Format is used:
+
+* The Credential Format identifier MUST be `mso_mdoc`.
+* The ISO mdoc Credential Format specific DCQL parameter, `intent_to_retain` defined in Annex B.3.1 of [@!OIDF.OID4VP] MUST be present.
 * When multiple ISO mdocs are being returned, each ISO mdoc MUST be returned in a separate `DeviceResponse` (as defined in 8.3.2.1.2.2 of [@!ISO.18013-5]), each matching to a respective DCQL query. Therefore, the resulting `vp_token` contains multiple `DeviceResponse` instances.
 
-Note that the Credential Format Identifier and `SessionTranscript` CBOR structures are defined in [@!OIDF.OID4VP].
+The `SessionTranscript` CBOR structure MUST be used as follows:
 
-## IETF SD-JWT VC specific requirements for OpenID for Verifiable Presentations
+* For (#oid4vp-redirects): the `SessionTranscript` CBOR structure defined in Section B.2.6.1 in [@!OIDF.OID4VP].
+* For (#oid4vp-dc-api): the `SessionTranscript` CBOR structure defined in Section B.2.6.2 in [@!OIDF.OID4VP].
 
-Requirements for both the Wallet and the Verifier:
+### IETF SD-JWT VC
+
+The following requirements apply to all OpenID4VP flows when the SD-JWT VC Credential Format is used:
 
 * The Credential Format identifier MUST be `dc+sd-jwt`.
 
-# SD-JWT VCs {#sd-jwt-vc}
+# Credential Formats {#credential-formats}
+
+Credentials MUST use one of the following Credential Formats:
+
+* IETF SD-JWT VC, subject to the additional requirements defined in (#sd-jwt-vc).
+* ISO mdocs
+
+## IETF SD-JWT VC Profile {#sd-jwt-vc}
 
 This profile defines the following additional requirements for IETF SD-JWT VCs as defined in [@!I-D.ietf-oauth-sd-jwt-vc].
 
@@ -261,15 +278,15 @@ Note: If there is a requirement to provide the Subject’s identifier assigned a
 
 Note: In some Credential Types, it is not desirable to include an expiration date (eg: diploma attestation). Therefore, this profile leaves its inclusion to the Issuer, or the body defining the respective Credential Type.
 
-## Issuer identification and key resolution to validate an issued Credential {#issuer-key-resolution}
+### Issuer identification and key resolution to validate an issued Credential {#issuer-key-resolution}
 
 This profile mandates the support for X.509 certificate-based key resolution to validate the issuer signature of an SD-JWT VC. This MUST be supported by all entities (Issuer, Wallet, Verifier). The SD-JWT VC MUST contain the credential issuer's certificate along with a trust chain in the `x5c` JOSE header parameter as described in section 3.5 of [@!I-D.ietf-oauth-sd-jwt-vc].
 
-### Cryptographic Holder Binding between VC and VP
+#### Cryptographic Holder Binding between VC and VP
 
 * For Cryptographic Holder Binding, a KB-JWT, as defined in [@!I-D.ietf-oauth-sd-jwt-vc], MUST always be present when presenting an SD-JWT VC.
 
-## OpenID4VC Credential Format Profile {#vc_sd_jwt_profile}
+### OpenID4VC Credential Format Profile {#vc_sd_jwt_profile}
 
 A Credential Format Profile for Credentials complying with IETF SD-JWT VCs [@!I-D.ietf-oauth-sd-jwt-vc] is defined in Annex A.3 of [@!OIDF.OID4VCI] and Annex A.4 of [@!OIDF.OID4VP].
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -205,7 +205,7 @@ The following requirements apply to OpenID4VP via redirects, unless specified ot
 * Response encryption MUST be used by utilizing response mode `direct_post.jwt`, as defined in Section 8.3 of [@!OIDF.OID4VP]. Security Considerations in Section 14.3 of [@!OIDF.OID4VP] MUST be applied.
 * Same-device flows MUST be used by enforcing `redirect_uri` in response to the HTTP POST request from the Wallet, as defined in Section 8.2 of [@!OIDF.OID4VP]. Implementation considerations in Section 13.3 and Security Considerations in Section 14.2 of [@!OIDF.OID4VP] MUST be applied. Verifiers MUST abort the validation if the `redirect_uri` was not called by the Wallet or could not be matched with the initial browser session.
 
-### OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}
+## OpenID for Verifiable Presentations via W3C Digital Credentials API {#oid4vp-dc-api}
 
 The following requirements apply to OpenID4VP via the W3C Digital Credentials API, unless specified otherwise:
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -482,6 +482,7 @@ The technology described in this specification was made available from contribut
    * Old link in section 8 & clarify a note on claim based binding in OpenID4VP in HAIP #183
    * Clarify clause 4.1 statement #169
    * add a list of all specifications being profiled #145
+   * refactor sections to align ISO mdoc issuance and presentation with SD-JWT VC
 
    -03
 


### PR DESCRIPTION
fixes #206 
partially fixes #225 but perhaps it fixes it entirely @c2bo , what do you think (since you created the issue)?

This PR refactors the OID4VP related sections to make it clear that ISO mdocs are included in the OID4VP profile defined in HAIP. Furthermore, it removes PEX references and redundant normative statements that require DCQL.

I kept the SD-JWT VC requirements for OID4VP section but tbh, after PEX got removed, there is not much to require there that is not mandated by OID4VP.

IMO, we don't even need to require the format identifier for SD-JWT VC since it is given by OID4VP but I kept it for discussion.

resolves #161 
resolves #98 