### PR TITLE
Editorial: Combine the two 'Issuer Metdata' sections

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -126,6 +126,11 @@ Both Wallet initiated and Issuer initiated issuance are supported.
 
 ## Issuer Metadata
 
+The Authorization Server MUST support metadata according to [@!RFC8414].
+
+The Credential Issuer MUST support metadata retrieval according to Section 12.2.2 of [@!OIDF.OID4VCI].
+The Credential Issuer metadata MUST include a scope for every Credential Configuration it supports.
+
 When ecosystem policies require Issuer Authentication to a higher level than possible with TLS alone, signed Credential Issuer Metadata as specified in Section 11.2.3 in [@!OIDF.OID4VCI]
 MUST be supported by both the Wallet and the Issuer. Key resolution to validate the signed Issuer
 Metadata MUST be supported using the `x5c` JOSE header parameter as defined in [@!RFC7515].
@@ -173,13 +178,6 @@ Individual Wallet Attestations MUST be used for each Issuer and they MUST not co
 ### Key Attestation {#key-attestation}
 
 Wallets MUST support key attestations as defined in Annex D of [@!OIDF.OID4VCI]. If batch issuance is used and the Credential Issuer has indicated (via `cryptographic_binding_methods_supported` metadata parameter) that cryptographic holder binding is required, all public keys used in Credential Request SHOULD be attested within a single key attestation.
-
-## Issuer Metadata
-
-The Authorization Server MUST support metadata according to [@!RFC8414].
-
-The Credential Issuer MUST support metadata retrieval according to Section 12.2.2 of [@!OIDF.OID4VCI].
-The Credential Issuer metadata MUST include a scope for every Credential Configuration it supports.
 
 # OpenID for Verifiable Presentations
 


### PR DESCRIPTION
We had two subsections within the same section both titled "Issuer Metadata" - combine them into a single section.

closes #246