### PR TITLE
Resolve issue with conflicting 'MUST' & 'SHOULD' for key attestations

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -171,14 +171,14 @@ Individual Wallet Attestations MUST be used for each Issuer and they MUST not co
 
 ## Credential Endpoint
 
-The following proof types MUST be supported:
+### Key Attestation {#key-attestation}
+
+Wallets MUST support key attestations. Ecosystems that desire wallet-issuer interoperability on the level of key attestations SHOULD require Wallets to support the format specified in Annex D of [@!OIDF.OID4VCI], in combination with the following proof types:
 
 * `jwt` proof type using `key_attestation`
 * `attestation` proof type
 
-### Key Attestation {#key-attestation}
-
-Wallets MUST support key attestations. Ecosystems that desire wallet-issuer interoperability on the level of key attestations SHOULD require Wallets to support the format specified in Annex D of [@!OIDF.OID4VCI]. Alternatively, ecosystems MAY choose to rely on other key attestation formats.
+Alternatively, ecosystems MAY choose to rely on other key attestation formats.
 
 If batch issuance is used and the Credential Issuer has indicated (via `cryptographic_binding_methods_supported` metadata parameter) that cryptographic holder binding is required, all public keys used in Credential Request SHOULD be attested within a single key attestation.
 


### PR DESCRIPTION
The 'MUST' for the proof types supported was not intended to be a MUST given we now have only a 'SHOULD' in the following section for supporting the key attestations format defined in OID4VCI.

closes #270