### PR TITLE
Allow other Wallet Attestation formats

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -155,22 +155,25 @@ Both Issuer and Wallet MUST support Credential Offer in both same-device and cro
 * MUST use Pushed Authorization Requests (PAR) [@!RFC9126] to send the Authorization Request.
 * Wallets MUST authenticate themselves at the PAR endpoint using the same rules as defined in (#token-endpoint) for client authentication at the token endpoint.
 * MUST use the `scope` parameter to communicate Credential Type(s) to be issued. The scope value MUST map to a specific Credential Type. The scope value may be pre-agreed, obtained from the Credential Offer, or the Credential Issuer Metadata.
-* The `client_id` value in the PAR request MUST be a string that the Wallet has used as the `sub` value in the client attestation JWT.
 
 ## Token Endpoint {#token-endpoint}
 
-* The Wallets MUST perform client authentication as defined in (#wallet-attestation).
 * Refresh tokens are RECOMMENDED to be supported for Credential refresh. For details, see Section 13.5 in [@!OIDF.OID4VCI].
 
 Note: Issuers SHOULD be mindful of how long the usage of the refresh token is allowed to refresh a credential, as opposed to starting the issuance flow from the beginning. For example, if the User is trying to refresh a Credential more than a year after its original issuance, the usage of the refresh tokens is NOT RECOMMENDED.
 
 ### Wallet Attestation {#wallet-attestation}
 
-Wallets MUST use Wallet Attestations as defined in Annex E of [@!OIDF.OID4VCI].
+Wallets and Issuers MUST use an OAuth Client authentication mechanism at the PAR/Token endpoints.
 
-The public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT.
+Ecosystems that desire wallet-issuer interoperability on the level of wallet attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other wallet attestation formats and mechanisms.
 
-Individual Wallet Attestations MUST be used for each Issuer and they MUST not contain unique identifiers that would enable linkability between issuance processes. See section 14.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
+ Additional rules apply for the format defined in Annex E of [@!OIDF.OID4VCI]:
+
+* the public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
+* individual Wallet Attestations MUST be used for each Issuer and they MUST not contain unique identifiers that would enable linkability between issuance processes. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
+* the `client_id` value in the PAR request MUST be a string that the Wallet has used as the `sub` value in the client attestation JWT.
+* Wallets MUST perform client authentication with the Wallet Attestation at the Token Endpoint
 
 ## Credential Endpoint
 
@@ -520,7 +523,7 @@ The technology described in this specification was made available from contribut
 
    -05
 
-   * TBC
+   * change wallet attesation format from mandatory to recommended
 
    -04
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -181,7 +181,7 @@ Ecosystems that desire wallet-issuer interoperability on the level of Wallet Att
  Additional rules apply when using the format defined in Annex E of [@!OIDF.OID4VCI]:
 
 * the public key certificate, and optionally a trust certificate chain excluding the trust anchor, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
-* Wallet Attestations MUST NOT be reused across different Issuers. They MUST NOT introduce a unique identifier specific to a single Client Instance. The subject claim for the Wallet Attestation MUST be a value that is shared by all Wallet instances using the present type of wallet implementation. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
+* Wallet Attestations MUST NOT be reused across different Issuers. They MUST NOT introduce a unique identifier specific to a single Wallet instance. The subject claim for the Wallet Attestation MUST be a value that is shared by all Wallet instances using the present type of wallet implementation. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
 * if applicable, the `client_id` value in the PAR request MUST be the string in the `sub` value in the client attestation JWT.
 * Wallets MUST perform client authentication with the Wallet Attestation at OAuth2 Endpoints that support client authentication.
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -180,9 +180,9 @@ Ecosystems that desire wallet-issuer interoperability on the level of Wallet Att
 
  Additional rules apply when using the format defined in Annex E of [@!OIDF.OID4VCI]:
 
-* the public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
-* individual Wallet Attestations MUST be used for each Issuer. They MUST not contain unique identifiers that would enable linkability between issuance processes. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
-* the `client_id` value in the PAR request MUST be the string in the `sub` value in the client attestation JWT.
+* the public key certificate, and optionally a trust certificate chain excluding the trust anchor, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
+* Wallet Attestations MUST NOT be reused across different Issuers. They MUST NOT introduce a unique identifier specific to a single Client Instance. The subject claim for the Wallet Attestation MUST be a value that is shared by all Wallet instances using the present type of wallet implementation. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
+* if applicable, the `client_id` value in the PAR request MUST be the string in the `sub` value in the client attestation JWT.
 * Wallets MUST perform client authentication with the Wallet Attestation at OAuth2 Endpoints that support client authentication.
 
 ## Credential Endpoint

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -172,7 +172,7 @@ Wallets MUST use, and Issuers MUST require, an OAuth2 Client authentication mech
 
 Ecosystems that desire wallet-issuer interoperability on the level of Wallet Attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other Wallet Attestation formats.
 
- Additional rules apply for the format defined in Annex E of [@!OIDF.OID4VCI]:
+ Additional rules apply when using the format defined in Annex E of [@!OIDF.OID4VCI]:
 
 * the public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
 * individual Wallet Attestations MUST be used for each Issuer and they MUST not contain unique identifiers that would enable linkability between issuance processes. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -164,7 +164,7 @@ Note: Issuers SHOULD be mindful of how long the usage of the refresh token is al
 
 ### Wallet Attestation {#wallet-attestation}
 
-Wallets and Issuers MUST use an OAuth Client authentication mechanism at the PAR and Token endpoints.
+Wallets MUST use, and Issuers MUST require, an OAuth2 Client authentication mechanism at OAuth2 Endpoints that support client authentication (such as the PAR and Token Endpoints).
 
 Ecosystems that desire wallet-issuer interoperability on the level of Wallet Attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other Wallet Attestation formats.
 
@@ -172,8 +172,8 @@ Ecosystems that desire wallet-issuer interoperability on the level of Wallet Att
 
 * the public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT 
 * individual Wallet Attestations MUST be used for each Issuer and they MUST not contain unique identifiers that would enable linkability between issuance processes. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
-* the `client_id` value in the PAR request MUST be a string that the Wallet has used as the `sub` value in the client attestation JWT.
-* Wallets MUST perform client authentication with the Wallet Attestation at the Token Endpoint
+* the `client_id` value in the PAR request MUST be the string in the `sub` value in the client attestation JWT.
+* Wallets MUST perform client authentication with the Wallet Attestation at OAuth2 Endpoints that support client authentication.
 
 ## Credential Endpoint
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -166,7 +166,7 @@ Note: Issuers SHOULD be mindful of how long the usage of the refresh token is al
 
 Wallets and Issuers MUST use an OAuth Client authentication mechanism at the PAR and Token endpoints.
 
-Ecosystems that desire wallet-issuer interoperability on the level of Wallet Attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other Wallet Attestation formats and mechanisms.
+Ecosystems that desire wallet-issuer interoperability on the level of Wallet Attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other Wallet Attestation formats.
 
  Additional rules apply for the format defined in Annex E of [@!OIDF.OID4VCI]:
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -164,9 +164,9 @@ Note: Issuers SHOULD be mindful of how long the usage of the refresh token is al
 
 ### Wallet Attestation {#wallet-attestation}
 
-Wallets and Issuers MUST use an OAuth Client authentication mechanism at the PAR/Token endpoints.
+Wallets and Issuers MUST use an OAuth Client authentication mechanism at the PAR and Token endpoints.
 
-Ecosystems that desire wallet-issuer interoperability on the level of wallet attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other wallet attestation formats and mechanisms.
+Ecosystems that desire wallet-issuer interoperability on the level of Wallet Attestations SHOULD require Wallets to support the authentication mechanism and Wallet Attestation format specified in Annex E of [@!OIDF.OID4VCI]. When doing so, they might need to define additional ecosystem-specific claims contained in the attestation. Alternatively, ecosystems MAY choose to rely on other Wallet Attestation formats and mechanisms.
 
  Additional rules apply for the format defined in Annex E of [@!OIDF.OID4VCI]:
 


### PR DESCRIPTION
Proposal making the wallet attestations format recommended instead of mandatory. Happy to change the text if we get consensus on the wg for a different path, but this seemed to be the current outcome?

closes #211