### PR TITLE
fix: update crypto suites to require at least ECDSA w/ P-256 and SHA-256

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -130,6 +130,7 @@ Both Wallet initiated and Issuer initiated issuance are supported.
 
 If batch issuance is supported, the Wallet SHOULD use it rather than making consecutive requests for a single Credential of the same Credential Dataset. The Issuer MUST indicate whether batch issuance is supported by including or omitting the `batch_credential_issuance` metadata parameter. The Issuer’s decision may be influenced by various factors, including, but not limited to, trust framework requirements, regulatory constraints, applicable laws or internal policies.
 
+Additional requirements for OpenID4VCI are defined in (#crypto-suites) and (#hash-algorithms).
 
 ## Issuer Metadata
 
@@ -203,7 +204,7 @@ The following requirements apply to OpenID4VP, irrespective of the flow and Cred
 * Verifiers MUST use ephemeral encryption keys specific to each Authorization Request passed via client metadata as specified in Section 8.3 of [@!OIDF.OID4VP].
 * The Authority Key Identifier (`aki`)-based Trusted Authority Query (`trusted_authorities`) for DCQL, as defined in section 6.1.1.1 of [@!OIDF.OID4VP], MUST be supported. Note that the Authority Key Identifiers mechanism can be used to support multiple X.509-based trust mechanisms, such as ISO mDL VICAL (as introduced in [@ISO.18013-5]) or ETSI Trusted Lists [@ETSI.TL]. This is achieved by collecting the relevant X.509 certificates for the trusted Issuers and including the encoded Key Identifiers from the certificates in the `aki` array .
 
-Additional requirements for OpenID4VP are defined in (#oid4vp-redirects), (#oid4vp-dc-api) and (#oid4vp-credential-formats).
+Additional requirements for OpenID4VP are defined in (#oid4vp-redirects), (#oid4vp-dc-api), (#oid4vp-credential-formats), (#crypto-suites) and (#hash-algorithms).
 
 Note that while this document does not define profiles for X.509 certificates used in Verifier authentication (e.g., with the `x509_hash` Client Identifier Prefix), ecosystems are encouraged to define their own certificate issuing policies and certificate profiles. Such policies and profiles MAY specify how information in the certificate corresponds to information in the presentation flows. For example, an ecosystem might require that the Wallet verifies that the `redirect_uri`, `response_uri`, `origin`, or `expected_origin` request parameters match with information contained in the Verifier's end-entity certificate (e.g., its DNS name).
 
@@ -276,20 +277,33 @@ This profile mandates the support for X.509 certificate-based key resolution to 
 
 * If the credential has cryptographic holder binding, a KB-JWT, as defined in [@!I-D.ietf-oauth-sd-jwt-vc], MUST always be present when presenting an SD-JWT VC.
 
-# Crypto Suites
+# Crypto Suites {#crypto-suites}
 
 Cryptography is required by the following operations:
 
-- to sign and validate the signature on the Wallet Attestation and its proof of possession
+- to sign and validate the signature on the Wallet or Key Attestation and their proof of possession (PoP)
+- to sign and validate the signature of the status information of the Verifiable Credential or Wallet Attestation
 - to sign and validate the Issuer's signature on the Verifiable Credential
 - to sign and validate the Holder's signature on the Verifiable Presentation
 - to sign and validate the Verifier's signature on the Presentation Request
 
-Issuers, Holders, and Verifiers MUST support P-256 (secp256r1) as a key type with the ES256 JWT algorithm [@!RFC7518] for the creation and verification of the above signatures.
+All parties MUST, at a minimum, support ECDSA with P-256 and SHA-256 (JOSE algorithm identifier `ES256`; COSE algorithm identifier `-7`) for the following:
+
+- Issuers
+  - validating Wallet Attestations (including PoP) when Annex E of [@!OIDF.OID4VCI] is used;
+  - validating Key Attestations when Annex D of [@!OIDF.OID4VCI] is used.
+- Verifiers
+  - validating the signature of the Verifiable Presentation, e.g., KB-JWT of an SD-JWT VC, or `deviceSignature` CBOR structure in case of ISO mdocs. Verifiers are assumed to determine in advance the cryptographic suites supported by the ecosystem, e.g. mDL Issuers/Verifiers implementing ISO mdocs.
+- Wallets
+  - validating signed presentation requests.
+
+Although support for the above algorithm is mandatory, an Issuer, Verifier, or Wallet MAY reject a particular cryptographic suite or the corresponding protected artifact if there are reasonable security, privacy, or policy concerns (e.g., suspected compromise or non-compliance). Such decisions are out of scope of the algorithm requirements but can be necessary in real-world deployments.
+
+Ecosystem-specific profiles MAY mandate additional or alternative cryptographic suites.
 
 When using this profile alongside other crypto suites, each entity SHOULD make it explicit in its metadata which other algorithms and key types are supported for the cryptographic operations.
 
-# Hash Algorithms
+# Hash Algorithms {#hash-algorithms}
 
 The hash algorithm SHA-256 MUST be supported by all the entities to generate and validate the digests in the IETF SD-JWT VC and ISO mdoc.
 
@@ -533,7 +547,7 @@ The technology described in this specification was made available from contribut
 
    -05
 
-   * TBC
+   * update crypto suites to require at least ECDSA w/ P-256 and SHA-256 for verifying signed artificats
 
    -04
 


### PR DESCRIPTION
- fixes #112 
- update crypto suites to require at least ECDSA w/ P-256 and SHA-256