### PR TITLE
Tweak security considerations reference to OID4VP/VCI

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -303,7 +303,7 @@ Wallet implementations using the key attestation format specified in Annex D of 
 
 # Security Considerations {#security_considerations}
 
-Note that security considerations for OpenID for Verifiable Credential Issuance are defined in [@!OIDF.OID4VCI] and for OpenID for Verifiable Presentations in [@!OIDF.OID4VP].
+Note that security considerations for OpenID for Verifiable Credential Issuance are defined in Section 13 of [@!OIDF.OID4VCI] and for OpenID for Verifiable Presentations in Section 14 (for redirect based flows) or Section A.5 (for DC API) of [@!OIDF.OID4VP].
 
 ## Incomplete or Incorrect Implementations of the Specifications and Conformance Testing
 

--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -303,7 +303,7 @@ Wallet implementations using the key attestation format specified in Annex D of 
 
 # Security Considerations {#security_considerations}
 
-The security considerations in [@!OIDF.OID4VCI] and [@!OIDF.OID4VP] apply.
+Note that security considerations for OpenID for Verifiable Credential Issuance are defined in [@!OIDF.OID4VCI] and for OpenID for Verifiable Presentations in [@!OIDF.OID4VP].
 
 ## Incomplete or Incorrect Implementations of the Specifications and Conformance Testing
 


### PR DESCRIPTION
Make it clearer we're just pointing out the existence of those sections and changing their normative status.