### PR TITLE
Re-fix reference to wallet attestation subject section in VCI

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-1_0.md
@@ -180,7 +180,7 @@ Wallets MUST use Wallet Attestations as defined in Annex E of [@!OIDF.OID4VCI].
 
 The public key certificate, and optionally a trust certificate chain, used to validate the signature on the Wallet Attestation MUST be included in the `x5c` JOSE header of the Client Attestation JWT.
 
-Individual Wallet Attestations MUST be used for each Issuer. They MUST not contain unique identifiers that would enable linkability between issuance processes. See section 14.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
+Individual Wallet Attestations MUST be used for each Issuer. They MUST not contain unique identifiers that would enable linkability between issuance processes. See section 15.4.4 of [@!OIDF.OID4VCI] for details on the Wallet Attestation subject.
 
 ## Credential Endpoint
 


### PR DESCRIPTION
The change to fix this was already applied in #279 but was reverted in https://github.com/openid/OpenID4VC-HAIP/pull/288 during git conflict resolution.